### PR TITLE
[IMP] adding a default config table for easier setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,25 @@ This will later become a true plugin managing the download of the server executa
 We recommend using nvim version `0.11.0` or later to benefit from the builtin lsp config helpers.
 Working with `< 0.11` will require installing [lspconfig](https://github.com/neovim/nvim-lspconfig)
 
+## Instalation
+For now the language server is not included in the plugin. The plugin defines the config for neovim.
+First download the [language server releases](https://github.com/odoo/odoo-ls/releases). 
+The plugin will search for the server either directly on the path or inside the 
+"$HOME/.local/share/nvim/odoo/odoo_ls_server" folder. For custom locations, the 
+config will need to be update as in the [config section](#lspconfiglua-custom-config)
+
+Additionally, the server requires the [python typeshed](https://github.com/python/typeshed).
+The server will look for the stdlib either in the same folder as the server binary
+or in the current working directory. Otherwise the stdlib can be configured both in the
+[odools.toml](#odoolstoml) or [config](#lspconfiglua-custom-config)
+
 ## Configs
 
-There are 2 configuration parts needed. One for the server directly, and one for neovim. This
-later should be integrated in the future plugin.
+There are 2 configuration parts needed. One for the server directly, and one for neovim. 
+
+The odools.toml file should be included in the root of you working directory and define the
+addons, stubs and python path (if you need to use a different python executable such as a 
+the one from a virtual environment). 
 
 ### odools.toml
  ```toml
@@ -31,34 +46,37 @@ python_path = "/home/user/.pyenv/shims/python"
 additional_stubs = ["/home/user/.local/nvim/odoo/typeshed/stubs"]
 ```
 
-### nvim
+You can import the odoo-nvim plugin to provide a default setting for the odoo_ls.
 
-The server need a bit of configuration to work smothly with neovim. Here is the minimal suggested config.
-
+### lazy.lua
 ```lua
--- Defined in <rtp>/lsp/odools.lua
-local server = '/home/user/.local/share/nvim/odoo/odoo_ls_server'
--- Get the default client capabilities
-local capabilities = vim.lsp.protocol.make_client_capabilities()
+    {'odoo/odoo-neovim'}
+```
 
--- Add your custom capability
-capabilities.general.markdown = {
-  parser = 'marked',
-  version = ''
-}
-return {
-  cmd = {server, '--stdlib', vim.fn.fnamemodify(server, ':h') .. '/typeshed/stdlib'},
-  root_dir = '/home/whe/.local/share/nvim/odoo',
-  filetypes = { 'python' },
-  workspace_folders = {{
-      uri = vim.uri_from_fname('/home/whe/src'),
-      name = 'main_folder',
-  }},
-  capabilities = capabilities,
-  settings = {
-      Odoo = {
-          selectedProfile = 'main',
-      }
-  },
-}
+### lspconfig.lua (in nvim >0.11)
+```lua
+vim.lsp.config("odoo_ls", {
+    -- custom config if needed
+    })
+
+vim.lsp.enable({"odoo_ls"})
+```
+
+The config can be customised depending on the needs. Multiple commands exist and can
+be found on the [cli page of the server](https://github.com/odoo/odoo-ls/blob/release/server/src/args.rs).
+But for setup reasons some notable ones are:
+- --config-path - a specific path where to find the odools.toml
+- --stdlib - give an alternative path to stdlib stubs from typeshed
+
+### lspconfig.lua custom config
+```lua
+vim.lsp.config("odoo_ls", {
+    cmd = {
+        -- Path to the odoo_ls_server binary
+        vim.fn.expand('$HOME/.local/share/nvim/odoo/odoo_ls_server'),
+        '--config-path',
+        'Path_to_toml/odools.toml',
+        '--stdlib',
+        'path_to_typeshed/stdlib',
+    })
 ```

--- a/lsp/odoo_ls.lua
+++ b/lsp/odoo_ls.lua
@@ -1,0 +1,30 @@
+-- This file provides the default configuration for the 'odoo_ls' server.
+
+local odoo_ls_locations = {
+    vim.fn.expand('$HOME/.local/share/nvim/odoo/odoo_ls_server'),
+    "odoo_ls_server"
+}
+
+local executable = ''
+
+for _, location in ipairs(odoo_ls_locations) do
+    if vim.fn.executable(location) then
+        executable = location
+    end
+end
+
+return {
+    cmd = {
+        executable,
+    },
+    filetypes = { 'python', 'xml' },
+    workspace_folders = { {
+        uri = vim.uri_from_fname(vim.fn.getcwd()),
+        name = 'main_folder'
+    } },
+    settings = {
+        Odoo = {
+            selectedProfile = 'main',
+        }
+    },
+}


### PR DESCRIPTION
Added a default config table to allow users to setup the server with an empty config
The config will detect the current working directory of nvim and use that as a workspace root and check of odools.toml
Changed the readme to specify the usage of the default config table and added some clarity on the default expectations of the language server.