### PR TITLE
[FIX] Added '== 1' to executable existance check

### DIFF
--- a/lsp/odoo_ls.lua
+++ b/lsp/odoo_ls.lua
@@ -8,7 +8,7 @@ local odoo_ls_locations = {
 local executable = ''
 
 for _, location in ipairs(odoo_ls_locations) do
-    if vim.fn.executable(location) then
+    if vim.fn.executable(location) == 1 then
         executable = location
     end
 end


### PR DESCRIPTION
The vim.fn.executable returns 0 if the path doesn't exist, but lua treats 0 as true, so the then block of the condition always gets executed, so the last executable form the odoo_ls_locations will be used for the cmd, even if it doesn't exist on the system.

Now with this it should properly evaluate whether the path exists and only if it does use it for cmd.